### PR TITLE
chore: prepare railway deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app

--- a/README.MD
+++ b/README.MD
@@ -106,6 +106,13 @@ Antes de rodar o projeto localmente, você precisa obter uma chave de API da Ope
     ```
 3.  Acesse `http://127.0.0.1:5000/` no seu navegador.
 
+## Deploy no Railway
+
+1. Crie uma conta em [Railway](https://railway.app/) e conecte este repositório no painel web ou via [Railway CLI](https://docs.railway.app/reference/cli).
+2. Ao criar o serviço, o Railway instalará automaticamente as dependências de `requirements.txt` e usará o `Procfile` para iniciar o servidor com `gunicorn`.
+3. Defina as variáveis de ambiente necessárias no projeto (`OPENAI_API_KEY` e `FLASK_SECRET_KEY`). O Railway fornecerá automaticamente a variável `PORT`.
+4. Inicie o deploy; após a conclusão, a aplicação estará disponível na URL gerada pelo Railway.
+
 ## Como Usar a Aplicação
 
 1.  Acesse a URL no navegador.

--- a/app.py
+++ b/app.py
@@ -194,6 +194,12 @@ def report():
     # Exemplo: profile.interesses_principais, profile.soft_skills_identificadas_com_evidencia, etc.
     return render_template('report.html', profile=profile_data)
 
+# Inicializa o banco de dados ao carregar o aplicativo
+init_db()
+
 if __name__ == '__main__':
-    init_db() # Garante que a tabela student_ai_profiles seja criada/verificada.
-    app.run(debug=True, port=5000)
+    app.run(
+        debug=os.environ.get("FLASK_DEBUG", "").lower() == "true",
+        host="0.0.0.0",
+        port=int(os.environ.get("PORT", 5000)),
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 openai
 python-dotenv
+gunicorn


### PR DESCRIPTION
## Summary
- configure Flask to use PORT env var and auto-init DB
- add gunicorn and Procfile for Railway
- document Railway deployment instructions

## Testing
- `python -m py_compile app.py openai_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6890e79009748324bd40383939032599